### PR TITLE
Target SDKを35に上げます

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
 
 android {
     namespace = "jp.ikanoshiokara.dividash"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "jp.ikanoshiokara.dividash"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 5
         versionName = "1.0.3"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Dividash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/jp/ikanoshiokara/dividash/MainActivity.kt
+++ b/app/src/main/java/jp/ikanoshiokara/dividash/MainActivity.kt
@@ -3,6 +3,7 @@ package jp.ikanoshiokara.dividash
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -25,6 +26,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalSerializationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             DividashTheme {
                 val navController = rememberNavController()

--- a/app/src/main/java/jp/ikanoshiokara/dividash/ui/theme/Theme.kt
+++ b/app/src/main/java/jp/ikanoshiokara/dividash/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package jp.ikanoshiokara.dividash.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,11 +8,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val DarkColorScheme =
     darkColorScheme(
@@ -55,14 +50,6 @@ fun DividashTheme(
             darkTheme -> DarkColorScheme
             else -> LightColorScheme
         }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
 
     MaterialTheme(
         colorScheme = colorScheme,


### PR DESCRIPTION
# 対応するタスク
- close #24 

# 概要
<!-- Pull Requestの概要を書いてください -->
Target SDKを35にあげるために、statusBarを主にedge to edgeの対応をした

# 技術的変更点・追加点
<!-- 技術的な変更点・追加点を書いてください -->
- `enableEdgeToEdge()`を導入
- `Theme.kt`内のstatusBar関連の処理を削除

# 確認すること
<!-- レビュワーに確認して欲しいこと、何を確認できればマージできるかを書いてください -->
35以上の端末で動作確認

# UI(Optional)
<!-- UI系の変更であれば、スクリーンショットもしくは動画を添付してください -->
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

# その他特記事項(Optional)

# 確認事項
- [x] ラベルの設定/不要
- [x] Milestonesの設定/不要
- [x] Projectsへの追加/不要
- [x] 必須項目は埋めたか
- [x] UI系の変更であるか：UIセクションにスクショは忘れていないですか？